### PR TITLE
Fix Dockerfile errors

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -63,7 +63,7 @@ ENV LD_LIBRARY_PATH /.openmpi/lib:$LD_LIBRARY_PATH
 
 # install pytorch, torchvision.
 RUN git clone --recursive  https://github.com/pytorch/pytorch
-RUN conda install -y numpy
+RUN conda install -y numpy pyyaml
 RUN cd pytorch && \
     git checkout tags/v1.8.0 && \
     git submodule sync && \
@@ -71,7 +71,7 @@ RUN cd pytorch && \
     TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6" TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
     pip install -v .
-RUN conda install av -c conda-forge
+RUN conda install -c conda-forge 'ffmpeg<5'
 RUN git clone https://github.com/pytorch/vision.git && cd vision && git checkout tags/v0.9.2-rc2 && python setup.py install
 
 # tmux


### PR DESCRIPTION
Hello,

After some days debugging the Dockerfile we finally got it running. Here's a slightly modified version with two fixes:
* build process fails because of unavailable pyyaml package. It is added now next to the numpy installation.
* conda installs the latest av/ffmpeg version (>5), which isn't compatible with the pytorch-vision version used in the build (v0.9.2-rc2). Therefore we changed the conda install command to install ffmpeg<5.

There are also other changes we did to the Dockerfiles (both this one and the one in determinedai-container-scripts) related to which conda/ubuntu mirror repositories the build process should be using. As we are not located in China, we couldn't use those mirrors, so we just removed these lines. I don't feel comfortable pushing those changes to the repo, though, as it will be mostly user-dependent, but I suggest you provide an alternative Dockerfile to increase the outreach of your work :).

Thanks! 